### PR TITLE
basic docs and use reset attribute on forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+## goherence
+
+a go implementation of [coherence-framework](https://github.com/dominictarr/coherence)
+
+## example
+
+there is a running example:
+``` js
+cd futz
+go run main.go
+```
+(the first time you run it will take a little while to start up)
+
+then open [http://localhost:3001](http://localhost:3001)
+in your browser.
+
+

--- a/futz/main.go
+++ b/futz/main.go
@@ -32,7 +32,7 @@ const (
 {{ end -}}
 
 {{ define "simple-form" -}}
-<form method="POST" action="endpoint/{{ . }}">
+<form method="POST" action="endpoint/{{ . }}" data-reset="true">
 	<input type="text" name="msg">
 	<input type="submit" value="{{ . }} it">
 </form>


### PR DESCRIPTION
I got the example working, and documented what you need to run to make it work)

I also added the data-reset option to the form. This intercepts the form submit button, and submits the form using javascript - which means it can update the form without updating the page.

because the example is so small, it was hard to notice the screen updating, but if you don't blink you can see it. with reset, the form is submitted via javascript, and the invalidated elements should update.
(documentation for [reset](https://github.com/dominictarr/coherence#attributes---forms) that I just wrote)

It seems this uncovered a bug - I tried mashing the keyboard, making many updates (into the send input) and after a few inputs, maybe 10 within a few seconds, it seems to get stuck. If I reload the page, they were received, but it seems it didn't respond to the longpoll cache request correctly?